### PR TITLE
New Plugin: AWIN for Publisher

### DIFF
--- a/plugins/awin-publisher.json
+++ b/plugins/awin-publisher.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+	"id": "awin-publisher",
+	"name": "AWIN Publisher",
+	"description": "AWIN is a global affiliate plattform. This plugin allows you to download invoices from your AWIN publisher account.",
+	"homepage": "https://awin.com",
+	"configSchema": {},
+	"checkAuth": [
+		{
+			"action": "navigate",
+			"url": "https://ui.awin.com/user"
+		},
+		{
+			"action": "checkElementExists",
+			"selector": "#accountsOverview"
+		}
+	],
+	"startAuth": [
+		{
+			"action": "navigate",
+			"url": "https://ui.awin.com/idp/en/awin/login"
+		},
+		{
+			"action": "waitForElement",
+			"selector": "app-total-earnings",
+			"timeout": 120000
+		}
+	],
+	"getDocuments": [
+    {
+			"action": "navigate",
+			"url": "https://ui.awin.com/user"
+		},
+    {
+			"action": "extractAll",
+			"selector": "li.affiliateDetail",
+			"variable": "account",
+			"fields": {
+				"id": {
+					"selector": "small"
+				}
+			},
+			"forEach": [
+        {
+          "action": "navigate",
+          "url": "https://ui.awin.com/finance/publisher/{{account.id}}/payments/history/network/awin"
+        },
+        {
+          "action": "extractAll",
+          "selector": "#payments ul li",
+          "variable": "currency",
+          "fields": {
+            "code": {
+              "selector": "a"
+            },
+            "url": {
+              "selector": "a",
+              "attribute": "href"
+            }
+          },
+          "forEach": [
+            {
+              "action": "navigate",
+              "url": "{{currency.url}}"
+            },
+            {
+              "action": "waitForElement",
+              "selector": "#paymentHistory table"
+            },
+            {
+              "action": "extractAll",
+              "selector": "#paymentHistory table tbody tr",
+              "variable": "invoice",
+              "fields": {
+                "id": {
+                  "selector": "td:nth-child(1) a",
+                  "attribute": "href",
+                  "transform": "(url) => url.split('/')[5]"
+                },
+                "date": {
+                  "selector": "td:nth-child(1)"
+                },
+                "total": {
+                  "selector": ".total"
+                },
+                "url": {
+                  "selector": ".csvIcon a:nth-child(3)",
+                  "attribute": "href"
+                }
+              },
+              "forEach": [
+                {
+                  "action": "downloadPdf",
+                  "url": "https://ui.awin.com{{invoice.url}}",
+                  "document": {
+                    "type": "outgoing_invoice",
+                    "id": "{{invoice.id}}",
+                    "date": "{{invoice.date}}",
+                    "total": "{{invoice.total}} {{currency.code}}"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+		}
+	]
+}

--- a/plugins/awin-publisher.json
+++ b/plugins/awin-publisher.json
@@ -27,11 +27,11 @@
 		}
 	],
 	"getDocuments": [
-    {
+		{
 			"action": "navigate",
 			"url": "https://ui.awin.com/user"
 		},
-    {
+		{
 			"action": "extractAll",
 			"selector": "li.affiliateDetail",
 			"variable": "account",
@@ -41,69 +41,69 @@
 				}
 			},
 			"forEach": [
-        {
-          "action": "navigate",
-          "url": "https://ui.awin.com/finance/publisher/{{account.id}}/payments/history/network/awin"
-        },
-        {
-          "action": "extractAll",
-          "selector": "#payments ul li",
-          "variable": "currency",
-          "fields": {
-            "code": {
-              "selector": "a"
-            },
-            "url": {
-              "selector": "a",
-              "attribute": "href"
-            }
-          },
-          "forEach": [
-            {
-              "action": "navigate",
-              "url": "{{currency.url}}"
-            },
-            {
-              "action": "waitForElement",
-              "selector": "#paymentHistory table"
-            },
-            {
-              "action": "extractAll",
-              "selector": "#paymentHistory table tbody tr",
-              "variable": "invoice",
-              "fields": {
-                "id": {
-                  "selector": "td:nth-child(1) a",
-                  "attribute": "href",
-                  "transform": "(url) => url.split('/')[5]"
-                },
-                "date": {
-                  "selector": "td:nth-child(1)"
-                },
-                "total": {
-                  "selector": ".total"
-                },
-                "url": {
-                  "selector": ".csvIcon a:nth-child(3)",
-                  "attribute": "href"
-                }
-              },
-              "forEach": [
-                {
-                  "action": "downloadPdf",
-                  "url": "https://ui.awin.com{{invoice.url}}",
-                  "document": {
-                    "type": "outgoing_invoice",
-                    "id": "{{invoice.id}}",
-                    "date": "{{invoice.date}}",
-                    "total": "{{invoice.total}} {{currency.code}}"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
+				{
+					"action": "navigate",
+					"url": "https://ui.awin.com/finance/publisher/{{account.id}}/payments/history/network/awin"
+				},
+				{
+					"action": "extractAll",
+					"selector": "#payments ul li",
+					"variable": "currency",
+					"fields": {
+						"code": {
+							"selector": "a"
+						},
+						"url": {
+							"selector": "a",
+							"attribute": "href"
+						}
+					},
+					"forEach": [
+						{
+							"action": "navigate",
+							"url": "{{currency.url}}"
+						},
+						{
+							"action": "waitForElement",
+							"selector": "#paymentHistory table"
+						},
+						{
+							"action": "extractAll",
+							"selector": "#paymentHistory table tbody tr",
+							"variable": "invoice",
+							"fields": {
+								"id": {
+									"selector": "td:nth-child(1) a",
+									"attribute": "href",
+									"transform": "(url) => url.split('/')[5]"
+								},
+								"date": {
+									"selector": "td:nth-child(1)"
+								},
+								"total": {
+									"selector": ".total"
+								},
+								"url": {
+									"selector": ".csvIcon a:nth-child(3)",
+									"attribute": "href"
+								}
+							},
+							"forEach": [
+								{
+									"action": "downloadPdf",
+									"url": "https://ui.awin.com{{invoice.url}}",
+									"document": {
+										"type": "outgoing_invoice",
+										"id": "{{invoice.id}}",
+										"date": "{{invoice.date}}",
+										"total": "{{invoice.total}} {{currency.code}}"
+									}
+								}
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/plugins/financeads-publisher.json
+++ b/plugins/financeads-publisher.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+	"id": "financeads-publisher",
+	"name": "financeAds Publisher",
+	"description": "financeAds is a affiliate plattform. This plugin allows you to download invoices from your financeAds publisher account.",
+	"homepage": "https://www.financeads.net/",
+	"configSchema": {},
+	"checkAuth": [
+		{
+			"action": "navigate",
+			"url": "https://dashboard.financeads.net/publisher/start"
+		},
+		{
+			"action": "checkElementExists",
+			"selector": "fads-affiliate-dashboard"
+		}
+	],
+	"startAuth": [
+		{
+			"action": "navigate",
+			"url": "https://dashboard.financeads.net/login"
+		},
+		{
+			"action": "waitForElement",
+			"selector": ".fads-affiliate-dashboard",
+			"timeout": 120000
+		}
+	],
+	"getDocuments": [
+		{
+			"action": "navigate",
+			"url": "https://dashboard.financeads.net/publisher/meinkonto/auszahlung"
+		},
+		{
+			"action": "extractAll",
+			"selector": "#auszahlung-card > .card-body > div:not(.d-none) > .row",
+			"variable": "invoice",
+			"fields": {
+				"id": {
+					"selector": "a",
+					"attribute": "title"
+				},
+				"date": {
+					"selector": ".row"
+				},
+				"total": {
+					"selector": "div:nth-child(2) > .row > div:last-child"
+				},
+				"url": {
+					"selector": "a",
+					"attribute": "href"
+				}
+			},
+			"forEach": [
+				{
+					"action": "downloadPdf",
+					"url": "{{invoice.url}}",
+					"document": {
+						"type": "outgoing_invoice",
+						"id": "{{invoice.id}}",
+						"date": "{{invoice.date}}",
+						"total": "{{invoice.total}}"
+					}
+				}
+			]
+		}
+	]
+}

--- a/plugins/impact-publisher.json
+++ b/plugins/impact-publisher.json
@@ -1,0 +1,84 @@
+{
+	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+	"id": "impact-publisher",
+	"name": "Impact Publisher",
+	"description": "Impact is a global affiliate plattform. This plugin allows you to download invoices from your Impact publisher account.",
+	"homepage": "https://impact.com/",
+	"configSchema": {},
+	"checkAuth": [
+		{
+			"action": "navigate",
+			"url": "https://app.impact.com/secure/mediapartner/home/pview.ihtml"
+		},
+		{
+			"action": "checkElementExists",
+			"selector": "#partnerFinanceSnapshot"
+		}
+	],
+	"startAuth": [
+		{
+			"action": "navigate",
+			"url": "https://app.impact.com/login.user"
+		},
+		{
+			"action": "waitForElement",
+			"selector": "#partnerFinanceSnapshot",
+			"timeout": 120000
+		}
+	],
+	"getDocuments": [
+		{
+			"action": "navigate",
+			"url": "https://app.impact.com/secure/mediapartner/PUB_FINANCE_Report/r3/report/viewReport.report?handle=mp_invoice_history"
+		},
+		{
+			"action": "waitForElement",
+			"selector": "div[class^='partitionFree']:not(.header-partition) .tr",
+			"timeout": 3000
+		},
+		{
+			"action": "extractAll",
+			"selector": "div[class^='partitionFree']:not(.header-partition) .tr",
+			"variable": "invoice",
+			"fields": {
+				"id": {
+					"selector": "[data-key='PDF'] a",
+					"attribute": "href",
+					"transform": "(url) => url.split('invoiceNumber=')[1]"
+				},
+				"date": {
+					"selector": "[data-key='Date']"
+				},
+				"total": {
+					"selector": "[data-key='Invoice_Amount']"
+				},
+				"url": {
+					"selector": "[data-key='PDF'] a",
+					"attribute": "href"
+				},
+				"billedto": {
+					"selector": "[data-key='Invoiced_entity']"
+				},
+				"tax": {
+					"selector": "[data-key='Tax']"
+				}
+			},
+			"forEach": [
+				{
+					"action": "downloadPdf",
+					"url": "https://app.impact.com{{invoice.url}}",
+					"document": {
+						"type": "outgoing_invoice",
+						"id": "{{invoice.id}}",
+						"date": "{{invoice.date}}",
+						"total": "{{invoice.total}}"
+					},
+					"metadata": {
+						"billedto": "{{invoice.billedto}}",
+						"tax": "{{invoice.tax}}"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Hey,

I just gave Invoice Radar a try and built my first plugin for AWIN, a global affiliate network. It fetches all outgoing invoices from a publisher account (advertiser accounts have invoices, too, but I am only a publisher). It supports multiple account per user and multiple currencies.