### PR TITLE
More Affiliate Networks

### DIFF
--- a/plugins/adrecord-publisher.json
+++ b/plugins/adrecord-publisher.json
@@ -1,67 +1,67 @@
 {
-	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
-	"id": "adrecord-publisher",
-	"name": "Adrecord Publisher",
-	"description": "Adrecord is a affiliate plattform. This plugin allows you to download invoices from your Adrecord publisher account.",
-	"homepage": "https://www.adrecord.com",
-	"configSchema": {},
-	"checkAuth": [
-		{
-			"action": "navigate",
-			"url": "https://www.adrecord.com/en/dashboard"
-		},
-		{
-			"action": "checkElementExists",
-			"selector": "a[href$='/logout']"
-		}
-	],
-	"startAuth": [
-		{
-			"action": "navigate",
-			"url": "https://www.adrecord.com/en/login"
-		},
-		{
-			"action": "waitForElement",
-			"selector": "a[href$='/logout']",
-			"timeout": 120000
-		}
-	],
-	"getDocuments": [
-		{
-			"action": "navigate",
-			"url": "https://www.adrecord.com/en/payments"
-		},
-		{
-			"action": "extractAll",
-			"selector": "table#DataTables_Table_0 tbody tr",
-			"variable": "invoice",
-			"fields": {
-				"id": {
-					"selector": "td"
-				},
-				"date": {
-					"selector": "td:nth-child(2)"
-				},
-				"total": {
-					"selector": "td:nth-child(4)"
-				},
-				"url": {
-					"selector": "a[href^='/en/payments/']",
-					"attribute": "href"
-				}
-			},
-			"forEach": [
-				{
-					"action": "downloadPdf",
-					"url": "https://www.adrecord.com{{invoice.url}}",
-					"document": {
-						"type": "outgoing_invoice",
-						"id": "{{invoice.id}}",
-						"date": "{{invoice.date}}",
-						"total": "{{invoice.total}}"
-					}
-				}
-			]
-		}
-	]
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "adrecord-publisher",
+  "name": "Adrecord Publisher",
+  "description": "Adrecord is a affiliate plattform. This plugin allows you to download invoices from your Adrecord publisher account.",
+  "homepage": "https://www.adrecord.com",
+  "configSchema": {},
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://www.adrecord.com/en/dashboard"
+    },
+    {
+      "action": "checkElementExists",
+      "selector": "a[href$='/logout']"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://www.adrecord.com/en/login"
+    },
+    {
+      "action": "waitForElement",
+      "selector": "a[href$='/logout']",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://www.adrecord.com/en/payments"
+    },
+    {
+      "action": "extractAll",
+      "selector": "table#DataTables_Table_0 tbody tr",
+      "variable": "invoice",
+      "fields": {
+        "id": {
+          "selector": "td"
+        },
+        "date": {
+          "selector": "td:nth-child(2)"
+        },
+        "total": {
+          "selector": "td:nth-child(4)"
+        },
+        "url": {
+          "selector": "a[href^='/en/payments/']",
+          "attribute": "href"
+        }
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "https://www.adrecord.com{{invoice.url}}",
+          "document": {
+            "type": "outgoing_invoice",
+            "id": "{{invoice.id}}",
+            "date": "{{invoice.date}}",
+            "total": "{{invoice.total}}"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/easymarketing-publisher.json
+++ b/plugins/easymarketing-publisher.json
@@ -1,79 +1,79 @@
 {
-	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
-	"id": "easymarketing-publisher",
-	"name": "Easy Marketing Publisher",
-	"description": "Easy Marketing offers a affiliate plattform. This plugin allows you to download invoices from your Easy Marketing publisher account.",
-	"homepage": "https://www.easy-m.de/",
-	"configSchema": {
-		"domain": {
-			"type": "string",
-			"title": "Domain",
-			"description": "Easy Marketing Domain",
-			"required": true
-		}
-	},
-	"checkAuth": [
-		{
-			"action": "navigate",
-			"url": "https://{{config.domain}}/overview.do"
-		},
-		{
-			"action": "checkElementExists",
-			"selector": "a[href='/logout.do']"
-		}
-	],
-	"startAuth": [
-		{
-			"action": "navigate",
-			"url": "https://{{config.domain}}/overview.do"
-		},
-		{
-			"action": "waitForElement",
-			"selector": "a[href='/logout.do']",
-			"timeout": 120000
-		}
-	],
-	"getDocuments": [
-		{
-			"action": "navigate",
-			"url": "https://{{config.domain}}/user-billings.do"
-		},
-		{
-			"action": "waitForNetworkIdle",
-			"timeout": 1000
-		},
-		{
-			"action": "extractAll",
-			"selector": "#content table tbody tr",
-			"variable": "invoice",
-			"fields": {
-				"id": {
-					"selector": "a[href^='user-billings.do']",
-					"transform": "(d) => d.replace('.pdf', '')"
-				},
-				"date": {
-					"selector": "td:nth-child(2) div"
-				},
-				"total": {
-					"selector": "td:nth-child(5)"
-				},
-				"url": {
-					"selector": "a[href^='user-billings.do']",
-					"attribute": "href"
-				}
-			},
-			"forEach": [
-				{
-					"action": "downloadPdf",
-					"url": "https://{{config.domain}}/{{invoice.url}}",
-					"document": {
-						"type": "outgoing_invoice",
-						"id": "{{invoice.id}}",
-						"date": "{{invoice.date}}",
-						"total": "{{invoice.total}}"
-					}
-				}
-			]
-		}
-	]
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "easymarketing-publisher",
+  "name": "Easy Marketing Publisher",
+  "description": "Easy Marketing offers a affiliate plattform. This plugin allows you to download invoices from your Easy Marketing publisher account.",
+  "homepage": "https://www.easy-m.de/",
+  "configSchema": {
+    "domain": {
+      "type": "string",
+      "title": "Domain",
+      "description": "Easy Marketing Domain",
+      "required": true
+    }
+  },
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://{{config.domain}}/overview.do"
+    },
+    {
+      "action": "checkElementExists",
+      "selector": "a[href='/logout.do']"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://{{config.domain}}/overview.do"
+    },
+    {
+      "action": "waitForElement",
+      "selector": "a[href='/logout.do']",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://{{config.domain}}/user-billings.do"
+    },
+    {
+      "action": "waitForNetworkIdle",
+      "timeout": 1000
+    },
+    {
+      "action": "extractAll",
+      "selector": "#content table tbody tr",
+      "variable": "invoice",
+      "fields": {
+        "id": {
+          "selector": "a[href^='user-billings.do']",
+          "transform": "(d) => d.replace('.pdf', '')"
+        },
+        "date": {
+          "selector": "td:nth-child(2) div"
+        },
+        "total": {
+          "selector": "td:nth-child(5)"
+        },
+        "url": {
+          "selector": "a[href^='user-billings.do']",
+          "attribute": "href"
+        }
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "https://{{config.domain}}/{{invoice.url}}",
+          "document": {
+            "type": "outgoing_invoice",
+            "id": "{{invoice.id}}",
+            "date": "{{invoice.date}}",
+            "total": "{{invoice.total}}"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/financequality-publisher.json
+++ b/plugins/financequality-publisher.json
@@ -1,78 +1,78 @@
 {
-	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
-	"id": "financequality-publisher",
-	"name": "FinanceQuality Publisher",
-	"description": "FinanceQuality is a affiliate plattform. This plugin allows you to download invoices from your FinanceQuality publisher account.",
-	"homepage": "https://www.financequality.net/",
-	"configSchema": {},
-	"checkAuth": [
-		{
-			"action": "navigate",
-			"url": "https://network.financequality.net/overview.do"
-		},
-		{
-			"action": "checkElementExists",
-			"selector": "#side-menu"
-		}
-	],
-	"startAuth": [
-		{
-			"action": "navigate",
-			"url": "https://network.financequality.net/index.do"
-		},
-		{
-			"action": "waitForElement",
-			"selector": "#side-menu",
-			"timeout": 120000
-		}
-	],
-	"getDocuments": [
-		{
-			"action": "navigate",
-			"url": "https://network.financequality.net/user-billings.do"
-		},
-		{
-			"action": "waitForNetworkIdle",
-			"timeout": 10000
-		},
-		{
-			"action": "extractAll",
-			"selector": "table tbody tr",
-			"variable": "invoice",
-			"fields": {
-				"id": {
-					"selector": "td a",
-					"transform": "(name) => name.split('.pdf')[0]"
-				},
-				"date": {
-					"selector": "td:nth-child(2)"
-				},
-				"total": {
-					"selector": "td:nth-child(6)"
-				},
-				"netto": {
-					"selector": "td.text-right"
-				},
-				"url": {
-					"selector": "td a",
-					"attribute": "href"
-				}
-			},
-			"forEach": [
-				{
-					"action": "downloadPdf",
-					"url": "https://network.financequality.net/{{invoice.url}}",
-					"document": {
-						"type": "outgoing_invoice",
-						"id": "{{invoice.id}}",
-						"date": "{{invoice.date}}",
-						"total": "{{invoice.total}}"
-					},
-					"metadata": {
-						"netto": "{{invoice.total}}"
-					}
-				}
-			]
-		}
-	]
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "financequality-publisher",
+  "name": "FinanceQuality Publisher",
+  "description": "FinanceQuality is a affiliate plattform. This plugin allows you to download invoices from your FinanceQuality publisher account.",
+  "homepage": "https://www.financequality.net/",
+  "configSchema": {},
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://network.financequality.net/overview.do"
+    },
+    {
+      "action": "checkElementExists",
+      "selector": "#side-menu"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://network.financequality.net/index.do"
+    },
+    {
+      "action": "waitForElement",
+      "selector": "#side-menu",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://network.financequality.net/user-billings.do"
+    },
+    {
+      "action": "waitForNetworkIdle",
+      "timeout": 10000
+    },
+    {
+      "action": "extractAll",
+      "selector": "table tbody tr",
+      "variable": "invoice",
+      "fields": {
+        "id": {
+          "selector": "td a",
+          "transform": "(name) => name.split('.pdf')[0]"
+        },
+        "date": {
+          "selector": "td:nth-child(2)"
+        },
+        "total": {
+          "selector": "td:nth-child(6)"
+        },
+        "netto": {
+          "selector": "td.text-right"
+        },
+        "url": {
+          "selector": "td a",
+          "attribute": "href"
+        }
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "https://network.financequality.net/{{invoice.url}}",
+          "document": {
+            "type": "outgoing_invoice",
+            "id": "{{invoice.id}}",
+            "date": "{{invoice.date}}",
+            "total": "{{invoice.total}}"
+          },
+          "metadata": {
+            "netto": "{{invoice.total}}"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/retailads-publisher.json
+++ b/plugins/retailads-publisher.json
@@ -1,67 +1,67 @@
 {
-	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
-	"id": "retailads-publisher",
-	"name": "retailAds Publisher",
-	"description": "retailAds is a affiliate plattform. This plugin allows you to download invoices from your financeAds publisher account.",
-	"homepage": "https://retailads.net/",
-	"configSchema": {},
-	"checkAuth": [
-		{
-			"action": "navigate",
-			"url": "https://dashboard.financeads.net/publisher/start"
-		},
-		{
-			"action": "checkElementExists",
-			"selector": "fads-affiliate-dashboard"
-		}
-	],
-	"startAuth": [
-		{
-			"action": "navigate",
-			"url": "https://login.retailads.net/partner/partner.php"
-		},
-		{
-			"action": "waitForElement",
-			"selector": "#logout",
-			"timeout": 120000
-		}
-	],
-	"getDocuments": [
-		{
-			"action": "navigate",
-			"url": "https://login.retailads.net/partner/partner.php?module=konto&site=auszahlungen"
-		},
-		{
-			"action": "extractAll",
-			"selector": "table#auszahlungen tbody tr",
-			"variable": "invoice",
-			"fields": {
-				"id": {
-					"selector": "td:nth-child(2)"
-				},
-				"date": {
-					"selector": "td:nth-child(1)"
-				},
-				"total": {
-					"selector": "td:nth-child(6)"
-				},
-				"url": {
-					"selector": "a",
-					"attribute": "href"
-				}
-			},
-			"forEach": [
-				{
-					"action": "downloadPdf",
-					"url": "{{invoice.url}}",
-					"document": {
-						"type": "outgoing_invoice",
-						"id": "{{invoice.id}}",
-						"date": "{{invoice.date}}",
-						"total": "{{invoice.total}}"
-					}
-				}
-			]
-		}
-	]
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "retailads-publisher",
+  "name": "retailAds Publisher",
+  "description": "retailAds is a affiliate plattform. This plugin allows you to download invoices from your financeAds publisher account.",
+  "homepage": "https://retailads.net/",
+  "configSchema": {},
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://dashboard.financeads.net/publisher/start"
+    },
+    {
+      "action": "checkElementExists",
+      "selector": "fads-affiliate-dashboard"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://login.retailads.net/partner/partner.php"
+    },
+    {
+      "action": "waitForElement",
+      "selector": "#logout",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://login.retailads.net/partner/partner.php?module=konto&site=auszahlungen"
+    },
+    {
+      "action": "extractAll",
+      "selector": "table#auszahlungen tbody tr",
+      "variable": "invoice",
+      "fields": {
+        "id": {
+          "selector": "td:nth-child(2)"
+        },
+        "date": {
+          "selector": "td:nth-child(1)"
+        },
+        "total": {
+          "selector": "td:nth-child(6)"
+        },
+        "url": {
+          "selector": "a",
+          "attribute": "href"
+        }
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "{{invoice.url}}",
+          "document": {
+            "type": "outgoing_invoice",
+            "id": "{{invoice.id}}",
+            "date": "{{invoice.date}}",
+            "total": "{{invoice.total}}"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/tradedoubler-publisher.json
+++ b/plugins/tradedoubler-publisher.json
@@ -1,67 +1,67 @@
 {
-	"$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
-	"id": "tradedoubler-publisher",
-	"name": "Tradedoubler Publisher",
-	"description": "Tradedoubler is a global affiliate plattform. This plugin allows you to download invoices from your Tradedoubler publisher account.",
-	"homepage": "https://www.tradedoubler.com",
-	"configSchema": {},
-	"checkAuth": [
-		{
-			"action": "navigate",
-			"url": "https://publishers.tradedoubler.com/en/publisher/dashboard/"
-		},
-		{
-			"action": "checkElementExists",
-			"selector": ".earning-item-title"
-		}
-	],
-	"startAuth": [
-		{
-			"action": "navigate",
-			"url": "https://publishers.tradedoubler.com/en/login"
-		},
-		{
-			"action": "waitForElement",
-			"selector": ".earning-item-title",
-			"timeout": 120000
-		}
-	],
-	"getDocuments": [
-		{
-			"action": "navigate",
-			"url": "https://publishers.tradedoubler.com/en/publisher/payments/?limit=100"
-		},
-		{
-			"action": "extractAll",
-			"selector": "table.payment_index tbody tr",
-			"variable": "invoice",
-			"fields": {
-				"id": {
-					"selector": "td:nth-child(2)"
-				},
-				"date": {
-					"selector": "td:nth-child(3)"
-				},
-				"total": {
-					"selector": "td:nth-child(4)"
-				},
-				"url": {
-					"selector": "a[title='Download']",
-					"attribute": "href"
-				}
-			},
-			"forEach": [
-				{
-					"action": "downloadPdf",
-					"url": "https://publishers.tradedoubler.com{{invoice.url}}",
-					"document": {
-						"type": "outgoing_invoice",
-						"id": "{{invoice.id}}",
-						"date": "{{invoice.date}}",
-						"total": "{{invoice.total}}"
-					}
-				}
-			]
-		}
-	]
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "tradedoubler-publisher",
+  "name": "Tradedoubler Publisher",
+  "description": "Tradedoubler is a global affiliate plattform. This plugin allows you to download invoices from your Tradedoubler publisher account.",
+  "homepage": "https://www.tradedoubler.com",
+  "configSchema": {},
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://publishers.tradedoubler.com/en/publisher/dashboard/"
+    },
+    {
+      "action": "checkElementExists",
+      "selector": ".earning-item-title"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://publishers.tradedoubler.com/en/login"
+    },
+    {
+      "action": "waitForElement",
+      "selector": ".earning-item-title",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://publishers.tradedoubler.com/en/publisher/payments/?limit=100"
+    },
+    {
+      "action": "extractAll",
+      "selector": "table.payment_index tbody tr",
+      "variable": "invoice",
+      "fields": {
+        "id": {
+          "selector": "td:nth-child(2)"
+        },
+        "date": {
+          "selector": "td:nth-child(3)"
+        },
+        "total": {
+          "selector": "td:nth-child(4)"
+        },
+        "url": {
+          "selector": "a[title='Download']",
+          "attribute": "href"
+        }
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "https://publishers.tradedoubler.com{{invoice.url}}",
+          "document": {
+            "type": "outgoing_invoice",
+            "id": "{{invoice.id}}",
+            "date": "{{invoice.date}}",
+            "total": "{{invoice.total}}"
+          }
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds more plugins for affiliate networks for publishers:

- Adrecord
- Easy Marketing
- FinanceQuality
- retailAds
- Tradedoubler
