### PR TITLE
Add Mailjet plugin configuration

### DIFF
--- a/plugins/mailjet.json
+++ b/plugins/mailjet.json
@@ -36,7 +36,7 @@
   "getDocuments": [
     {
       "action": "extractAll",
-      "script": "fetch('https://app.mailjet.com/account/billing/invoices?page=1&limit=100',{credentials:'include'}).then(r=>r.json()).then(d=>d.invoices.map(i=>({...i, date:new Intl.DateTimeFormat('en-CA').format(new Date(i.date*1000))})));",
+      "script": "fetch('https://app.mailjet.com/account/billing/invoices?page=1&limit=100',{credentials:'include'}).then(r=>r.json()).then(d=>d.invoices.map(i=>({...i, date:new Date(i.date*1000)})));",
       "forEach": [
         {
           "action": "downloadPdf",


### PR DESCRIPTION
Adds support for mailjet. 

I had to use "fetch" to call their private API as i'm having issues with "extractNetworkResponse". Ideally would be refactored in the future to remove the fetch call.