### PR TITLE
Add RevenueCat plugin configuration file

### DIFF
--- a/plugins/revenuecat.json
+++ b/plugins/revenuecat.json
@@ -36,7 +36,7 @@
   "getDocuments": [
     {
       "action": "extractAll",
-      "script": "fetch('https://app.revenuecat.com/v1/developers/me/invoices',{headers:{'x-requested-with':'XMLHttpRequest'},referrer:'https://app.revenuecat.com/settings/billing/invoices',credentials:'include'}).then(r=>r.json()).then(d=>d['invoices'].map(i=>({...i,amount_due:i.amount_due/100,date:new Intl.DateTimeFormat('en-CA').format(new Date(i.date*1000))})));",
+      "script": "fetch('https://app.revenuecat.com/v1/developers/me/invoices',{headers:{'x-requested-with':'XMLHttpRequest'},referrer:'https://app.revenuecat.com/settings/billing/invoices',credentials:'include'}).then(r=>r.json()).then(d=>d['invoices'].map(i=>({...i,amount_due:i.amount_due/100,date:new Date(i.date*1000)})));",
       "forEach": [
         {
           "action": "downloadPdf",


### PR DESCRIPTION
Adds support for revenuecat.

Nothing special here, I had to use fetch then mapped unix timestamps to YYYY-MM-DD format and divide amount_due by 100 because it's in cents.

I couldn't get the otp codes to work though, it asks the code in a popup window and invoice-radar does not add it automatically. I tried specifying a selector but same problem. I disabled otp codes for now. Might be worth investigating