### PR TITLE
Add rapidapi.com

### DIFF
--- a/plugins/rapidapi.json
+++ b/plugins/rapidapi.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://raw.githubusercontent.com/invoiceradar/plugins/main/schema.json",
+  "id": "rapidapi",
+  "name": "RapidAPI",
+  "description": "RapidAPI is a platform for building and consuming APIs.",
+  "homepage": "https://rapidapi.com",
+  "configSchema": {},
+  "checkAuth": [
+    {
+      "action": "navigate",
+      "url": "https://rapidapi.com/developer/billing/transaction-history"
+    },
+    {
+      "action": "checkURL",
+      "url": "https://rapidapi.com/developer/billing/transaction-history"
+    }
+  ],
+  "startAuth": [
+    {
+      "action": "navigate",
+      "url": "https://rapidapi.com/auth/login"
+    },
+    {
+      "action": "waitForURL",
+      "url": "https://rapidapi.com/**",
+      "timeout": 120000
+    }
+  ],
+  "getDocuments": [
+    {
+      "action": "navigate",
+      "url": "https://rapidapi.com/developer/billing/transaction-history"
+    },
+    {
+      "action": "waitForElement",
+      "selector": "table tbody tr:has(a[href*='invoice'])",
+      "iframe": "billing"
+    },
+    {
+      "action": "extractAll",
+      "selector": "table tbody tr",
+      "variable": "invoice",
+      "iframe": "billing",
+      "fields": {
+        "id": {
+          "selector": "td:nth-child(6) a[href*='invoice']",
+          "attribute": "href",
+          "transform": "(url) => url?.match(/\\/invoice\\/([^/?]+)/)?.[1]"
+        },
+        "date": "td:nth-child(5)",
+        "total": "td:nth-child(3)",
+        "url": {
+          "selector": "td:nth-child(6) a[href*='invoice']",
+          "attribute": "href"
+        }
+      },
+      "pagination": {
+        "selector": ".ant-pagination-next:not(.ant-pagination-disabled)",
+        "behavior": "paginateThenProcess"
+      },
+      "forEach": [
+        {
+          "action": "downloadPdf",
+          "url": "{{invoice.url}}",
+          "document": "{{invoice}}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a rapidapi.com plugin. Currently, it only supports personal accounts. To support organizations, we need to implement the `getConfigOptions` API.