### PR TITLE
Fix prettier workflow for fork PRs

### DIFF
--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Check formatting (PRs)

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -16,11 +16,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - name: Prettify code
+      - name: Check formatting (PRs)
+        if: github.event_name == 'pull_request'
+        run: npx prettier --check "plugins/*.json"
+
+      - name: Apply formatting (push to main)
+        if: github.event_name == 'push'
         uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write plugins/*.json

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Check formatting (PRs)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

The prettier workflow uses `ref: ${{ github.head_ref }}` which tries to checkout the PR branch from the base repository. For PRs from forks, this fails because the branch only exists in the contributor's fork.

## Solution

- **On PRs**: Checkout from the fork's repo/SHA and run `prettier --check` (read-only, no commit needed)
- **On push to main**: Keep the existing auto-commit behavior via `creyD/prettier_action`

This way fork PRs can be validated without needing write access to the fork.