### PR TITLE
fix(sentry): use relative URL to avoid CORS issues

### DIFF
--- a/plugins/sentry.json
+++ b/plugins/sentry.json
@@ -40,7 +40,7 @@
     },
     {
       "action": "extractAll",
-      "script": "fetch('https://sentry.io/api/0/customers/{{config.organization-id}}/invoices/', {\n  credentials: 'include',\n})\n  .then((res) => res.json())\n  .then((items) =>\n    items.map((item) => ({\n      id: item.id,\n      date: item.dateCreated,\n      total: 'USD ' + item.amount / 100,\n      url: item.receipt.url,\n    })),\n  )",
+      "script": "fetch('/api/0/customers/{{config.organization-id}}/invoices/', {\n  credentials: 'include',\n})\n  .then((res) => res.json())\n  .then((items) =>\n    items.map((item) => ({\n      id: item.id,\n      date: item.dateCreated,\n      total: 'USD ' + item.amount / 100,\n      url: item.receipt.url,\n    })),\n  )",
       "forEach": [
         {
           "action": "downloadPdf",


### PR DESCRIPTION
## Summary

- Changes the fetch URL from `https://sentry.io/api/0/...` to `/api/0/...`
- Eliminates cross-origin issues: the plugin runs inside `{org}.sentry.io` so a relative URL is always same-origin
- Root cause: unauthenticated requests to `sentry.io` return 401 without CORS headers, causing browsers to report "Failed to fetch" instead of the actual error