### PR TITLE
fix(scaleway): handle empty invoice state gracefully

### DIFF
--- a/plugins/scaleway.json
+++ b/plugins/scaleway.json
@@ -45,35 +45,44 @@
       "url": "https://console.scaleway.com/billing/payment"
     },
     {
-      "action": "waitForElement",
-      "selector": "table tbody button[aria-label^='download_invoice_']"
+      "action": "sleep",
+      "duration": 2000
     },
     {
-      "action": "extractAll",
-      "selector": "table tbody > tr[role='row']:has(button[aria-label^='download_invoice_'])",
-      "variable": "invoice",
-      "fields": {
-        "month": "td:nth-of-type(1)",
-        "year": "td:nth-of-type(2)",
-        "id": "td:nth-of-type(3)",
-        "paymentMethod": "td:nth-of-type(4)",
-        "status": "td:nth-of-type(5)",
-        "total": "td:nth-of-type(6)",
-        "downloadBtn": "button[aria-label^='download_invoice_']"
-      },
-      "forEach": [
+      "action": "waitForNetworkIdle"
+    },
+    {
+      "action": "if",
+      "selector": "table tbody button[aria-label^='download_invoice_']",
+      "then": [
         {
-          "action": "click",
-          "selector": "button[aria-label^='download_invoice_']",
-          "scopeSelector": true
-        },
-        {
-          "action": "waitForPdfDownload",
-          "document": {
-            "id": "{{invoice.id}}",
-            "date": "{{invoice.month}} {{invoice.year}}",
-            "total": "{{invoice.total}}"
-          }
+          "action": "extractAll",
+          "selector": "table tbody > tr[role='row']:has(button[aria-label^='download_invoice_'])",
+          "variable": "invoice",
+          "fields": {
+            "month": "td:nth-of-type(1)",
+            "year": "td:nth-of-type(2)",
+            "id": "td:nth-of-type(3)",
+            "paymentMethod": "td:nth-of-type(4)",
+            "status": "td:nth-of-type(5)",
+            "total": "td:nth-of-type(6)",
+            "downloadBtn": "button[aria-label^='download_invoice_']"
+          },
+          "forEach": [
+            {
+              "action": "click",
+              "selector": "button[aria-label^='download_invoice_']",
+              "scopeSelector": true
+            },
+            {
+              "action": "waitForPdfDownload",
+              "document": {
+                "id": "{{invoice.id}}",
+                "date": "{{invoice.month}} {{invoice.year}}",
+                "total": "{{invoice.total}}"
+              }
+            }
+          ]
         }
       ]
     }

--- a/plugins/scaleway.json
+++ b/plugins/scaleway.json
@@ -45,11 +45,8 @@
       "url": "https://console.scaleway.com/billing/payment"
     },
     {
-      "action": "sleep",
-      "duration": 2000
-    },
-    {
-      "action": "waitForNetworkIdle"
+      "action": "waitForCondition",
+      "script": "document.querySelector('table tbody') !== null"
     },
     {
       "action": "if",


### PR DESCRIPTION
## Summary

- Replaces bare `waitForElement` with `sleep` + `waitForNetworkIdle` + `if` selector check
- Accounts with no invoices (empty state: "Pas de facture en cours") now exit cleanly with 0 documents instead of timing out
- Selector-based check (`button[aria-label^='download_invoice_']`) is language-agnostic