### PR TITLE
fix(hetzner): skip invoice list items without PDF link

### DIFF
--- a/plugins/hetzner.json
+++ b/plugins/hetzner.json
@@ -37,7 +37,7 @@
     },
     {
       "action": "extractAll",
-      "selector": ".invoice-container .invoice-list li",
+      "selector": ".invoice-container .invoice-list li:has(a[href$='pdf'])",
       "fields": {
         "id": {
           "selector": "span.invoice-number"


### PR DESCRIPTION
## Problem

Invoice list items without a PDF link (e.g. payment detail blocks that appear for pending/outstanding invoices) were being extracted as empty objects `{}`. When `downloadPdf` tried to use `item.pdfLink` on these, it got `undefined`, causing:

> "Expected string, actual undefined: Received undefined"

## Fix

Narrow the `extractAll` selector from `li` to `li:has(a[href$='pdf'])` so only list items that actually contain a PDF download link are processed.

## Reproduces

