### PR TITLE
fix(blau): guard against missing billing account in API response

### DIFF
--- a/plugins/blau.json
+++ b/plugins/blau.json
@@ -48,7 +48,7 @@
     {
       "action": "extract",
       "variable": "account",
-      "script": "(async () => {\n  const base = 'https://www.blau.de/scs/bff/scs-207-customer-master-data-bff/customer-master-data/v1';\n  const r = await fetch(base + '/onload/multiple/invoiceContent', { credentials: 'include' });\n  const j = await r.json();\n  const bill = j.billingAccountList[0];\n  return {\n    billingAccountId: bill.billAccountNumber,\n    msisdn: bill.contractDetails[0].msisdn\n  };\n})()",
+      "script": "(async () => {\n  const base = 'https://www.blau.de/scs/bff/scs-207-customer-master-data-bff/customer-master-data/v1';\n  const r = await fetch(base + '/onload/multiple/invoiceContent', { credentials: 'include' });\n  const j = await r.json();\n  const bill = (j.billingAccountList || [])[0];\n  if (!bill) throw new Error('No billing account found in response');\n  return {\n    billingAccountId: bill.billAccountNumber,\n    msisdn: bill.contractDetails[0].msisdn\n  };\n})()",
       "description": "Fetch the billing account number and MSISDN from the customer master data API."
     },
     {


### PR DESCRIPTION
## Summary

- Adds a null guard on `billingAccountList[0]` in the account extraction script
- If the API returns an empty or missing `billingAccountList`, now throws a descriptive error instead of crashing with `TypeError: Cannot read properties of undefined (reading '0')`

## Root cause

The `/onload/multiple/invoiceContent` endpoint can return an empty `billingAccountList` (e.g. for certain account states). Previously this caused an unhandled TypeError that surfaced as a confusing crash.