### PR TITLE
fix(shutterstock): navigate directly to invoice URL instead of clicking link per row

### DIFF
--- a/plugins/shutterstock.json
+++ b/plugins/shutterstock.json
@@ -46,12 +46,9 @@
       "selector": "table > tbody > tr",
       "forEach": [
         {
-          "action": "click",
-          "selector": "a[data-automation$='_link']"
-        },
-        {
-          "action": "waitForURL",
-          "url": "https://www.shutterstock.com/de/account/invoice/*"
+          "action": "navigate",
+          "url": "https://www.shutterstock.com/de/account/invoice/{{item.invoiceNumber}}",
+          "waitForNetworkIdle": true
         },
         {
           "action": "printPdf",


### PR DESCRIPTION
## Problem

The `forEach` loop clicks `a[data-automation$='_link']` on each iteration, but after the first click the browser navigates to the invoice page — leaving the purchases table behind. Subsequent iterations time out trying to click a link that no longer exists on the page.

Errors:
- Invoice 2: `Timeout waiting for element to click: a[data-automation$='_link']`
- Invoice 3: `Cannot read properties of undefined (reading 'querySelector')` (cascading)

## Fix

Replace the click + `waitForURL` with a direct `navigate` to `https://www.shutterstock.com/de/account/invoice/{{item.invoiceNumber}}`. The invoice number is already extracted from the row, and the URL pattern is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)